### PR TITLE
drivers: adc: stm32g4 also have a shared IRQ for ADC instances

### DIFF
--- a/drivers/adc/Kconfig.stm32
+++ b/drivers/adc/Kconfig.stm32
@@ -13,7 +13,7 @@ config ADC_STM32
 	help
 	  Enable the driver implementation for the stm32xx ADC
 
-if SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X
+if SOC_SERIES_STM32F2X || SOC_SERIES_STM32F4X || SOC_SERIES_STM32F7X || SOC_SERIES_STM32G4X
 
 config ADC_STM32_SHARED_IRQS
 	bool "STM32 ADC shared interrupts"

--- a/drivers/adc/adc_stm32.c
+++ b/drivers/adc/adc_stm32.c
@@ -1361,7 +1361,11 @@ static const struct adc_driver_api api_stm32_driver_api = {
 
 bool adc_stm32_is_irq_active(ADC_TypeDef *adc)
 {
+#if defined(CONFIG_SOC_SERIES_STM32G4X)
+	return LL_ADC_IsActiveFlag_EOC(adc) ||
+#else
 	return LL_ADC_IsActiveFlag_EOCS(adc) ||
+#endif /* CONFIG_SOC_SERIES_STM32G4X */
 	       LL_ADC_IsActiveFlag_OVR(adc) ||
 	       LL_ADC_IsActiveFlag_JEOS(adc) ||
 	       LL_ADC_IsActiveFlag_AWD1(adc);


### PR DESCRIPTION
The adc1 & 2 of the stm32g4 devices share the same irq

Signed-off-by: Francois Ramu <francois.ramu@st.com>
Signed-off-by: Otavio Salvador <otavio@ossystems.com.br>
